### PR TITLE
Debug: Modal 컴포넌트 안의 Button 컴포넌트 스토리 id 정정

### DIFF
--- a/src/components/Modal.stories.mdx
+++ b/src/components/Modal.stories.mdx
@@ -134,7 +134,7 @@ export const Template = (args) => <Modal {...args} />;
   </Story>
 </Canvas>
 
-<Story id="feature-button--primary" />
+<Story id="components-button--primary" />
 
 ## Component Api
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정

### 반영 브랜치
ex) example-modal -> main

### 변경 사항
1. Debug: Modal 컴포넌트 안의 Button 컴포넌트 스토리 id 정정
Button story에 잘못된 id가 입력되어 Docs 에서 오류가 발생했던 것을 정정하였습니다.