### PR TITLE
Feat: DropDown ui / Search ui 속성 삭제 및 수정

### DIFF
--- a/src/components/DropDown/DropDown.stories.mdx
+++ b/src/components/DropDown/DropDown.stories.mdx
@@ -5,6 +5,14 @@ import DropDown from "./DropDown";
   title="Components/DropDown"
   component={DropDown}
   argTypes={{
+    width: {
+      name: "width",
+      type: { name: "string", required: false },
+      description: "You can handle the width property of DropDown.",
+      table: {
+        type: { summary: "string" },
+      },
+    },
     items: {
       name: "items",
       description:
@@ -58,6 +66,17 @@ import DropDown from "./DropDown";
       type: { name: "number", required: false },
       description: "Handling the z-index property of the DropDown.",
       defaultValue: 300,
+    },
+    onChange: {
+      name: "onChange",
+      type: { required: false },
+      description:
+        "onChange is a utility for this controlled component to communicate to a consuming component what kind of internal state changes are occurring.",
+      table: {
+        type: {
+          summary: "func",
+        },
+      },
     },
   }}
 />

--- a/src/components/DropDown/DropDown.style.tsx
+++ b/src/components/DropDown/DropDown.style.tsx
@@ -52,6 +52,7 @@ export const suggestion = (width: string, open: boolean, zIndex: number) => css`
   overflow-x: none;
   overflow-y: auto;
   outline: ${open ? "1px solid #0f62fe" : "none"};
+  outline-offset: -1px;
   z-index: ${zIndex};
 `;
 

--- a/src/components/DropDown/DropDown.tsx
+++ b/src/components/DropDown/DropDown.tsx
@@ -24,12 +24,9 @@ type DropDownProps = {
   hideWarn?: boolean;
   size?: string;
   zIndex?: number;
-  setSelected?: React.Dispatch<
-    React.SetStateAction<{
-      id: number | string;
-      value: number | string;
-    }>
-  >;
+  onChange?: (data: {
+    selectedItem: { id: number | string; value: number | string };
+  }) => void;
 };
 
 const DropDown = ({
@@ -44,7 +41,7 @@ const DropDown = ({
   hideWarn = false,
   size = "middle",
   zIndex = 300,
-  setSelected = () => {},
+  onChange = () => {},
 }: DropDownProps) => {
   const [open, setOpen] = useState(false);
   const [seletedItem, setSeletedItem] = useState(0);
@@ -63,16 +60,8 @@ const DropDown = ({
     index: number
   ) => {
     setSeletedItem(index);
-    setSelected({ id: id, value: value });
+    onChange({ selectedItem: { id: id, value: value } });
   };
-
-  // const buttonRef = useRef<any>(null);
-
-  // useLayoutEffect(() => {
-  //   if (buttonRef.current !== null && !open) {
-  //     buttonRef.current.focus();
-  //   }
-  // });
 
   return (
     <div css={style.container}>
@@ -95,9 +84,9 @@ const DropDown = ({
       </button>
 
       {open ? (
-        <div css={style.suggestion(width, open, zIndex)}>
+        <ul css={style.suggestion(width, open, zIndex)}>
           {items.map((item, index) => (
-            <div
+            <li
               key={item.id}
               css={style.suggestionItem(
                 index,
@@ -112,9 +101,9 @@ const DropDown = ({
               }}
             >
               <span>{item.value}</span>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       ) : null}
       {hideWarn ? null : <div css={style.helperText}>{warn}</div>}
     </div>

--- a/src/components/Search/Search.stories.mdx
+++ b/src/components/Search/Search.stories.mdx
@@ -35,22 +35,22 @@ import Search from "./Search";
       type: { name: "string", required: false },
       defaultValue: "",
     },
-    inputRef: {
-      name: "inputRef",
+    onKeyDown: {
+      name: "onKeyDown",
       type: { required: false },
       description:
-        "You can get the input's current value by using this property. Make a ref object by using useRef hook in React and give it to this inputRef property.",
+        "Provide an optional function to be called when a key event occured",
       table: {
         type: {
           summary: "func",
         },
       },
     },
-    onKeyUp: {
-      name: "onKeyUp",
+    onChange: {
+      name: "onChange",
       type: { required: false },
       description:
-        "Provide an optional function to be called when a key event occured",
+        "onChange is a utility for this controlled component to communicate to a consuming component what kind of internal state changes are occurring.",
       table: {
         type: {
           summary: "func",

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -6,21 +6,21 @@ import Close from "../../assets/icon/Close";
 import Magnifier from "../../assets/icon/Magnifier";
 
 type SearchProps = {
-  inputRef?: React.MutableRefObject<HTMLInputElement | null>;
   width?: string;
   disabled?: boolean;
   autoComplete?: string;
   placeholder?: string;
-  onKeyUp?: (event: any) => void;
+  onKeyDown?: (event: any) => void;
+  onChange?: (data: { value: string }) => void;
 };
 
 const Search = ({
-  inputRef,
   width = "100%",
   disabled = false,
   autoComplete = "off",
   placeholder = "placeholder",
-  onKeyUp = () => {},
+  onKeyDown = () => {},
+  onChange = () => {},
 }: SearchProps) => {
   const [value, setValue] = useState("");
 
@@ -30,6 +30,7 @@ const Search = ({
 
   const updateValue = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
+    onChange({ value: event.target.value });
   };
 
   return (
@@ -39,14 +40,13 @@ const Search = ({
       </span>
       <input
         id="search"
-        ref={inputRef}
         css={style.input}
         disabled={disabled}
         autoComplete={autoComplete}
         value={value}
         placeholder={placeholder}
         onChange={updateValue}
-        onKeyUp={onKeyUp}
+        onKeyDown={onKeyDown}
       />
       <span css={style.clearIcon(disabled)} onClick={clearInput}>
         <Close width={16} height={16} />


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 수정
- [x] 스타일 수정


### 반영 브랜치
chromatic -> main

### 변경 사항
1. Feat: DropDown ui의 setSelected 속성 삭제 / onChange 속성 추가
이전에는 사용자가 DropDown 내부 선택한 item 값을 가져오기 위해서 setState 함수(setSelected)를 props로 내려줘야 했습니다.
하지만 이번 업데이트부터는 setSelected 속성은 삭제되고 onChange 속성이 추가되었습니다.
사용자는 onChange 속성의 매개변수로부터 해당 value를 가져올 수 있습니다.<br><br>
2. Feat: Search ui의 inputRef 속성 삭제 / onChange,속성 추가
이전에는 사용자가 Search의 input value 값을 가져오기 위해서 useRef 객체(inputRef)를 props로 내려줘야 했습니다.
하지만 이번 업데이트부터는 inputRef 속성은 삭제되고 onChange 속성이 추가되었습니다.
사용자는 onChange 속성의 매개변수로부터 input에 입력된 value를 가져올 수 있습니다.<br><br>
3.  Search ui의 onKeyUp 속성 삭제 -> onKeyDown으로 대체
onKeyUp 이벤트가 onKeyDown 이벤트로 대체되었습니다.<br><br>
4. DropDown ui mdx 문서 수정 및 style 수정
DropDown ui mdx 문서에서 누락되어있던 width 속성 내용을 추가했습니다.
DropDown의 suggestion 요소의 outline이 요소 내부가 아닌 외부에서 구현되는 것을 outline-offset에 음수 값을 주어 
내부에서 구현되도록 수정했습니다.
