### PR TITLE
Feat: Checkbox, DataTable ui 추가

### DIFF
--- a/src/assets/icon/Checked.tsx
+++ b/src/assets/icon/Checked.tsx
@@ -6,14 +6,13 @@ const Checked = (props: SVGProps<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     width={16}
     height={16}
-    tabIndex={0}
+    viewBox="0 0 10 10"
     fill="none"
     {...props}
   >
     <path
-      d="M7.721 11.984a.637.637 0 0 1-.452-.188l-2.132-2.13a.64.64 0 0 1 .9-.9l1.68 1.678 4.236-4.237a.64.64 0 1 1 .9.9l-4.69 4.69a.637.637 0 0 1-.442.187Z"
+      d="M3.721 7.984a.637.637 0 0 1-.452-.188l-2.132-2.13a.64.64 0 0 1 .9-.9l1.68 1.678 4.236-4.237a.64.64 0 1 1 .9.9l-4.69 4.69a.637.637 0 0 1-.442.187Z"
       fill="#fff"
-      className="__web-inspector-hide-shortcut__"
     />
   </svg>
 );

--- a/src/assets/icon/Checked.tsx
+++ b/src/assets/icon/Checked.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { SVGProps } from "react";
+
+const Checked = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={16}
+    height={16}
+    tabIndex={0}
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M7.721 11.984a.637.637 0 0 1-.452-.188l-2.132-2.13a.64.64 0 0 1 .9-.9l1.68 1.678 4.236-4.237a.64.64 0 1 1 .9.9l-4.69 4.69a.637.637 0 0 1-.442.187Z"
+      fill="#fff"
+      className="__web-inspector-hide-shortcut__"
+    />
+  </svg>
+);
+
+export default Checked;

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -1,0 +1,32 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import Checkbox from "./Checkbox";
+
+<Meta title="Components/Checkbox" component={Checkbox} argTypes={{}} />
+
+# Checkbox
+
+## Overview
+
+Checkbox
+
+export const Template = (args) => <Checkbox {...args} />;
+
+## Note
+
+<Canvas>
+  <Story
+    name="Default"
+    args={{
+      id: 1,
+      hideLabel: false,
+      disabled: false,
+      onChange: (data) => console.log(data),
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Component Api
+
+<ArgsTable story="Default" />

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -1,26 +1,88 @@
 import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import Checkbox from "./Checkbox";
 
-<Meta title="Components/Checkbox" component={Checkbox} argTypes={{}} />
+<Meta
+  title="Components/Checkbox"
+  component={Checkbox}
+  argTypes={{
+    id: {
+      name: "id",
+      type: { name: "string | number", required: false },
+      description: "내부 `input`, `label` 요소의 `id` 값을 설정합니다.",
+    },
+    checked: {
+      name: "checked",
+      type: { name: "boolean", required: false },
+      description: "Checkbox의 체크 여부를 설정합니다.",
+    },
+    label: {
+      name: "label",
+      type: { name: "string", required: false },
+      description: "Checkbox의 오른쪽에 위치한 label 텍스트를 설정합니다.",
+    },
+    hideLabel: {
+      name: "hideLabel",
+      type: { name: "boolean", required: false },
+      description: "Checkbox의 라벨 표시 여부를 설정합니다.",
+    },
+    disabled: {
+      name: "disabled",
+      type: { name: "boolean", required: false },
+      description: "Checkbox의 사용 불가능 여부를 설정합니다.",
+    },
+    onClick: {
+      name: "onClick",
+      type: { required: false },
+      description: "Checkbox가 클릭될 때 실행할 함수를 설정할 수 있습니다.",
+      table: {
+        type: {
+          summary: "func",
+        },
+      },
+      control: {
+        type: null,
+      },
+    },
+    onChange: {
+      name: "onChange",
+      type: { required: false },
+      description:
+        "onChange 매개변수를 사용함으로써 Checkbox가 토글될 때마다 변하는 boolean 값을 가져올 수 있습니다.",
+      table: {
+        type: {
+          summary: "func",
+        },
+      },
+    },
+
+}}
+/>
 
 # Checkbox
 
 ## Overview
 
-Checkbox
+Checkbox는 목록에서 선택할 항목이 여러 개인 경우에 사용됩니다. 사용자는 0개, 1개 또는 원하는 수의 항목을 선택할 수 있습니다.
 
 export const Template = (args) => <Checkbox {...args} />;
 
 ## Note
 
+&bull;&nbsp; 여러 checkbox를 사용할 경우, 각각의 checkbox에 독립적인 id값을 부여해 주어야 합니다.<br/><br/>
+&bull;&nbsp; 'onChange' props를 통해서 Checkbox의 id와 checked 값을 가져올 수 있습니다.<br/>
+
+<div style={{ marginLeft: "30px" }}>
+  `ex) onChange={(data) => console.log(data.id, data.checked)}`
+</div>
+
 <Canvas>
   <Story
     name="Default"
     args={{
-      id: 1,
+      id: "example",
+      label: "Checkbox label",
       hideLabel: false,
       disabled: false,
-      onChange: (data) => console.log(data),
     }}
   >
     {Template.bind({})}

--- a/src/components/Checkbox/Checkbox.styles.tsx
+++ b/src/components/Checkbox/Checkbox.styles.tsx
@@ -1,0 +1,51 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { BodyStyles } from "../Typography/Typography";
+
+export const container = css`
+  ${BodyStyles.bodyCompact01}
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+  cursor: pointer;
+`;
+
+export const disabledCheckbox = css`
+  width: 16px;
+  height: 16px;
+  border: 1px solid #16161640;
+  border-radius: 1px;
+  box-sizing: border-box;
+  cursor: not-allowed;
+`;
+
+export const disabledCheckboxLabel = css`
+  padding-left: 6px;
+  color: #16161640;
+  user-select: none;
+  cursor: not-allowed;
+`;
+
+export const checkedCheckbox = css`
+  width: 16px;
+  height: 16px;
+  border: 1px solid black;
+  border-radius: 1px;
+  background-color: black;
+`;
+
+export const uncheckedCheckbox = css`
+  width: 16px;
+  height: 16px;
+  border: 1px solid black;
+  border-radius: 1px;
+`;
+
+export const checkboxLabel = css`
+  padding-left: 6px;
+  user-select: none;
+`;
+
+export const hiddenInput = css`
+  display: none;
+`;

--- a/src/components/Checkbox/Checkbox.styles.tsx
+++ b/src/components/Checkbox/Checkbox.styles.tsx
@@ -29,9 +29,10 @@ export const disabledCheckboxLabel = css`
 export const checkedCheckbox = css`
   width: 16px;
   height: 16px;
-  border: 1px solid black;
+  outline: 1px solid black;
   border-radius: 1px;
   background-color: black;
+  box-sizing: border-box;
 `;
 
 export const uncheckedCheckbox = css`
@@ -39,6 +40,7 @@ export const uncheckedCheckbox = css`
   height: 16px;
   border: 1px solid black;
   border-radius: 1px;
+  box-sizing: border-box;
 `;
 
 export const checkboxLabel = css`

--- a/src/components/Checkbox/Checkbox.styles.tsx
+++ b/src/components/Checkbox/Checkbox.styles.tsx
@@ -4,7 +4,7 @@ import { BodyStyles } from "../Typography/Typography";
 
 export const container = css`
   ${BodyStyles.bodyCompact01}
-  display: flex;
+  display: inline-flex;
   align-items: center;
   margin-bottom: 4px;
   cursor: pointer;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,69 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import * as style from "./Checkbox.styles";
+import React, { useState, useEffect } from "react";
+import Checked from "../../assets/icon/Checked";
+
+interface CheckboxProps {
+  id: number | null;
+  hideLabel: boolean;
+  disabled: boolean;
+  onChange: (data: { id: number | null; checked: boolean }) => void;
+}
+
+const Checkbox = ({ id, hideLabel, disabled, onChange }: CheckboxProps) => {
+  const [checked, setChecked] = useState(false);
+
+  const handleCheckbox = () => {
+    setChecked((checked) => !checked);
+  };
+
+  const onKeyDownEnter = (
+    event: React.KeyboardEvent<SVGSVGElement | HTMLDivElement>
+  ) => {
+    if (event.key === "Enter") {
+      handleCheckbox();
+    }
+  };
+
+  useEffect(() => {
+    onChange({ id, checked });
+  }, [checked]);
+
+  return (
+    <>
+      {disabled ? (
+        <div css={style.container}>
+          <div css={style.disabledCheckbox} />
+          {hideLabel ? null : (
+            <span css={style.disabledCheckboxLabel}>Checkbox label</span>
+          )}
+        </div>
+      ) : checked ? (
+        <label css={style.container} htmlFor={String(id)}>
+          <div css={style.checkedCheckbox}>
+            <Checked onKeyDown={onKeyDownEnter} />
+          </div>
+          {hideLabel ? null : (
+            <span css={style.checkboxLabel}>Checkbox label</span>
+          )}
+        </label>
+      ) : (
+        <label css={style.container} htmlFor={String(id)}>
+          <div css={style.uncheckedCheckbox} onKeyDown={onKeyDownEnter} />
+          {hideLabel ? null : (
+            <span css={style.checkboxLabel}>Checkbox label</span>
+          )}
+        </label>
+      )}
+      <input
+        id={String(id)}
+        css={style.hiddenInput}
+        type="checkbox"
+        onChange={handleCheckbox}
+      />
+    </>
+  );
+};
+
+export default Checkbox;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -4,30 +4,58 @@ import * as style from "./Checkbox.styles";
 import React, { useState, useEffect } from "react";
 import Checked from "../../assets/icon/Checked";
 
-interface CheckboxProps {
-  id: number | null;
-  hideLabel: boolean;
-  disabled: boolean;
-  onChange: (data: { id: number | null; checked: boolean }) => void;
+interface dataTypes {
+  id: string | number;
+  checked: boolean;
 }
 
-const Checkbox = ({ id, hideLabel, disabled, onChange }: CheckboxProps) => {
+interface CheckboxProps {
+  id?: string | number;
+  checked?: boolean;
+  label?: string;
+  hideLabel?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  onChange?: (data: dataTypes) => void;
+}
+
+const Checkbox = ({
+  id,
+  checked: checkedInputFromOutside,
+  label,
+  hideLabel,
+  disabled,
+  onClick = () => {},
+  onChange,
+}: CheckboxProps) => {
   const [checked, setChecked] = useState(false);
+
+  const handleClickCheckbox = () => {
+    onClick();
+  };
 
   const handleCheckbox = () => {
     setChecked((checked) => !checked);
   };
 
-  const onKeyDownEnter = (
-    event: React.KeyboardEvent<SVGSVGElement | HTMLDivElement>
-  ) => {
+  const onKeyDownEnter = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Enter") {
       handleCheckbox();
     }
   };
 
   useEffect(() => {
-    onChange({ id, checked });
+    if (checkedInputFromOutside) {
+      setChecked(true);
+    } else {
+      setChecked(false);
+    }
+  }, [checkedInputFromOutside]);
+
+  useEffect(() => {
+    if (id && onChange) {
+      onChange({ id, checked });
+    }
   }, [checked]);
 
   return (
@@ -36,34 +64,39 @@ const Checkbox = ({ id, hideLabel, disabled, onChange }: CheckboxProps) => {
         <div css={style.container}>
           <div css={style.disabledCheckbox} />
           {hideLabel ? null : (
-            <span css={style.disabledCheckboxLabel}>Checkbox label</span>
+            <span css={style.disabledCheckboxLabel}>{label}</span>
           )}
         </div>
       ) : checked ? (
-        <label css={style.container} htmlFor={String(id)}>
-          <div css={style.checkedCheckbox}>
-            <Checked onKeyDown={onKeyDownEnter} />
+        <label css={style.container} htmlFor={"checkbox" + id}>
+          <div
+            css={style.checkedCheckbox}
+            tabIndex={0}
+            onKeyDown={onKeyDownEnter}
+          >
+            <Checked />
           </div>
-          {hideLabel ? null : (
-            <span css={style.checkboxLabel}>Checkbox label</span>
-          )}
+          {hideLabel ? null : <span css={style.checkboxLabel}>{label}</span>}
         </label>
       ) : (
-        <label css={style.container} htmlFor={String(id)}>
-          <div css={style.uncheckedCheckbox} onKeyDown={onKeyDownEnter} />
-          {hideLabel ? null : (
-            <span css={style.checkboxLabel}>Checkbox label</span>
-          )}
+        <label css={style.container} htmlFor={"checkbox" + id}>
+          <div
+            css={style.uncheckedCheckbox}
+            tabIndex={0}
+            onKeyDown={onKeyDownEnter}
+          />
+          {hideLabel ? null : <span css={style.checkboxLabel}>{label}</span>}
         </label>
       )}
       <input
-        id={String(id)}
+        id={"checkbox" + id}
         css={style.hiddenInput}
         type="checkbox"
+        onClick={handleClickCheckbox}
         onChange={handleCheckbox}
       />
     </>
   );
 };
 
-export default Checkbox;
+export default React.memo(Checkbox);

--- a/src/components/DataTable/DataTable.stories.mdx
+++ b/src/components/DataTable/DataTable.stories.mdx
@@ -1,0 +1,109 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import DataTable from "./DataTable";
+
+<Meta
+  title="Components/DataTable"
+  component={DataTable}
+  argTypes={{
+    headerText: {
+      description:
+        "DataTable의 headerText를 설정합니다. 입력값이 빈 string일 경우 header가 사라집니다.",
+      type: { name: "string", required: false },
+    },
+    checkboxSelection: {
+      description: "checkbox 열의 구현 유무를 설정합니다.",
+      type: { name: "boolean", required: false },
+    },
+    columns: {
+      description:
+        "DataTable의 각 column 열의 이름과 너비를 설정합니다. 배열 내 데이터 구조는 `{field: string;, headerName: string;, width: string;}` 형태를 갖춰야 합니다. `field`는 rows의 `[사용자 설정 속성]`데이터와 연결되는 속성입니다.",
+      type: { name: "array", required: false },
+      table: {
+        type: {
+          summary: "array",
+        },
+      },
+      control: {
+        type: null,
+      },
+    },
+    rows: {
+      description:
+        "DataTable의 각 rows 행의 id와 rows 행 안의 각 cell들의 내용을 설정합니다. 배열 내 데이터 구조는 `{id: string | number;, [사용자 설정 속성] : [사용자 설정 속성값];}` 형태를 갖춰야 합니다. `[사용자 설정 속성]`은 columns의 `field` 데이터와 연결되는 속성입니다.",
+      type: { name: "array", required: false },
+      table: {
+        type: {
+          summary: "array",
+        },
+      },
+      control: {
+        type: null,
+      },
+    },
+  }}
+/>
+
+# DataTable
+
+## Overview
+
+DataTable은 행과 열을 사용하여 정보를 표시합니다. 데이터를 효율적으로 구성하고 표시하는 데 사용됩니다.
+
+export const Template = (args) => <DataTable {...args} />;
+
+## Note
+
+&bull;&nbsp; columns props에는 아래와 같은 데이터 형식이 포함된 배열을 넣어줘야 합니다.
+
+<div style={{ marginLeft: "30px" }}>
+ `columns = [{field: string;, headerName: string;, width: string;}]` 
+</div>
+&bull;&nbsp; 위 columns 데이터의 headerName은 DataTable의 열에 들어갈 이름에 해당합니다.<br/><br/><br/>
+&bull;&nbsp; rows props에는 아래와 같은 데이터 형식이 포함된 배열을 넣어줘야 합니다.
+<div style={{ marginLeft: "30px" }}>
+ `rows = [{id: string | number;, [사용자 설정 속성] : [사용자 설정 속성값];}]` 
+</div>
+&bull;&nbsp; 위 rows 데이터의 [사용자 설정 속성]은 columns 데이터의 field와 동일한 이름을 가져야 합니다. <br/><br/>
+&bull;&nbsp; 위 rows 데이터의 [사용자 설정 속성값]은 DataTable의 각 cell에 들어가게 됩니다.
+
+<Canvas>
+  <Story
+    name="Default"
+    args={{
+      headerText: "Datatable",
+      checkboxSelection: true,
+      columns: columns,
+      rows: rows,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Component Api
+
+<ArgsTable story="Default" />
+
+export const columns = [
+  {
+    field: "id",
+    headerName: "NO",
+    width: "50px",
+  },
+  {
+    field: "name",
+    headerName: "이름",
+    width: "70px",
+  },
+];
+
+export const rows = [
+  {
+    id: 1,
+    name: "박지훈",
+  },
+  {
+    id: 2,
+    name: "강백호",
+  },
+];

--- a/src/components/DataTable/DataTable.style.tsx
+++ b/src/components/DataTable/DataTable.style.tsx
@@ -1,0 +1,79 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { BodyStyles, FixedHeadingStyles } from "../Typography/Typography";
+
+export const container = () => css`
+  display: inline-flex;
+  flex-direction: column;
+`;
+
+export const header = () => css`
+  ${FixedHeadingStyles.heading03}
+  padding: 16px 0px 24px 16px;
+  background-color: #f4f4f4;
+`;
+
+export const tableContainer = () => css``;
+
+export const tableHead = () => css`
+  background-color: #e0e0e0;
+`;
+
+export const tableRow = () => css`
+  display: flex;
+`;
+
+export const tableHeadRadioCell = () =>
+  css`
+    width: 50px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  `;
+
+export const tableRadioCell = () =>
+  css`
+    width: 50px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-bottom: 1px solid #e0e0e0;
+  `;
+
+export const tableHeaderCell = (width: string) =>
+  css`
+    ${FixedHeadingStyles.heading01}
+    width: ${width};
+    height: 48px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  `;
+
+export const tableBody = () => css`
+  ${BodyStyles.bodyCompact01}
+  background-color: #f4f4f4;
+`;
+
+export const tableBodyRow = (checked: boolean) => css`
+  display: flex;
+  background-color: ${checked ? "#e8e8e8" : "#f4f4f4"};
+  &:hover {
+    background-color: #e8e8e8;
+    transition: 70ms;
+  }
+`;
+
+export const tableBodyCell = (width: string) => css`
+  width: ${width};
+  height: 55px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-bottom: 1px solid #e0e0e0;
+  color: #525252;
+  box-sizing: border-box;
+  overflow: hidden;
+`;
+
+export const noDataTableRow = () => css``;

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,157 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import * as style from "./DataTable.style";
+import React, { useState } from "react";
+import Checkbox from "../Checkbox/Checkbox";
+
+interface rowTypes {
+  [index: string]: string | number | boolean;
+  id: string | number;
+}
+
+interface columnTypes {
+  field: string;
+  headerName: string;
+  width: string;
+}
+
+interface dataTypes {
+  id: string | number;
+  checked: boolean;
+}
+
+interface DataTableProps {
+  headerText?: string;
+  checkboxSelection?: boolean;
+  columns?: columnTypes[];
+  rows?: rowTypes[];
+  onChange?: (data: Array<string | number | null>) => void;
+}
+
+const DataTable = ({
+  headerText,
+  checkboxSelection,
+  columns = [
+    {
+      field: "id",
+      headerName: "NO",
+      width: "50px",
+    },
+    {
+      field: "name",
+      headerName: "이름",
+      width: "70px",
+    },
+  ],
+  rows = [
+    {
+      id: 1,
+      name: "박지훈",
+    },
+    {
+      id: 2,
+      name: "강백호",
+    },
+  ],
+  onChange,
+}: DataTableProps) => {
+  const [checkedRowsIdArr, setCheckedRowsIdArr] = useState<
+    Array<string | number | null>
+  >([]);
+
+  const handleChangeAllCheckboxes = (data: dataTypes) => {
+    if (rows && data.checked) {
+      rows.map((row) =>
+        setCheckedRowsIdArr((checkedRowsIdArr) => [row.id, ...checkedRowsIdArr])
+      );
+    } else {
+      setCheckedRowsIdArr([]);
+    }
+  };
+
+  const handleChangeCheckbox = (data: dataTypes) => {
+    if (data.checked && !checkedRowsIdArr.includes(data.id)) {
+      setCheckedRowsIdArr((checkedRowsIdArr) => [data.id, ...checkedRowsIdArr]);
+    }
+
+    if (!data.checked) {
+      let filteredCheckedRowsIdArr = checkedRowsIdArr
+        .slice()
+        .filter((rowId) => data.id !== rowId);
+
+      setCheckedRowsIdArr(filteredCheckedRowsIdArr);
+    }
+  };
+
+  if (onChange) {
+    onChange(checkedRowsIdArr);
+  }
+
+  return (
+    <div css={style.container}>
+      {headerText ? <div css={style.header}>{headerText}</div> : null}
+      <div css={style.tableContainer}>
+        <div css={style.tableHead}>
+          <div css={style.tableRow}>
+            {checkboxSelection ? (
+              <div css={style.tableHeadRadioCell}>
+                <Checkbox
+                  id="selectAllCheckboxes"
+                  onChange={(data) => handleChangeAllCheckboxes(data)}
+                />
+              </div>
+            ) : null}
+
+            {columns &&
+              columns.length &&
+              columns.map((column, _) => (
+                <div
+                  key={column.field}
+                  css={style.tableHeaderCell(column.width)}
+                >
+                  {column.headerName}
+                </div>
+              ))}
+          </div>
+        </div>
+        <div css={style.tableBody}>
+          {rows && rows.length ? (
+            rows.map((row, _) => (
+              <div
+                key={row.id}
+                css={style.tableBodyRow(checkedRowsIdArr.includes(row.id))}
+              >
+                {checkboxSelection ? (
+                  <div css={style.tableRadioCell}>
+                    {
+                      <Checkbox
+                        id={row.id}
+                        checked={checkedRowsIdArr.includes(row.id)}
+                        onChange={(data) => handleChangeCheckbox(data)}
+                      />
+                    }
+                  </div>
+                ) : null}
+
+                {columns &&
+                  columns.length &&
+                  columns.map((column, _) => (
+                    <div
+                      key={column.field + row.id}
+                      css={style.tableBodyCell(column.width)}
+                    >
+                      {row[column.field]}
+                    </div>
+                  ))}
+              </div>
+            ))
+          ) : (
+            <div css={style.noDataTableRow}></div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DataTable;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
chromatic -> main

### 변경 사항
1. Checkbox ui 추가
사용자가 목록에서 선택할 항목이 여러 개인 경우에 사용합니다.
2. DataTable ui 추가
데이터를 효율적으로 구성하고 표시하는 데 사용
Checkbox ui 열도 만들어, DataTable의 특정 row 행을 선택가능하도록 하였습니다.