### PR TITLE
Fix: FileUploader, FileUpladerDropContainer ui - throw error에 대한 에러핸들링

### DIFF
--- a/src/components/FileUploader/FileUploader.stories.mdx
+++ b/src/components/FileUploader/FileUploader.stories.mdx
@@ -29,20 +29,6 @@ import FileUploader from "./FileUploader";
       },
       defaultValue: 0.5,
     },
-    onError: {
-      name: "onError",
-      type: { required: false },
-      description:
-        "FileUploader에 업로드할 수 있는 이미지 파일 사이즈 한도를 초과할 시, 실행할 함수를 설정할 수 있습니다.",
-      table: {
-        type: {
-          summary: "func",
-        },
-      },
-      defaultValue: () => {
-        console.log("업로드가 가능한 파일 사이즈를 초과했습니다.");
-      },
-    },
     onChange: {
       name: "onChange",
       type: { required: false },

--- a/src/components/FileUploader/FileUploader.tsx
+++ b/src/components/FileUploader/FileUploader.tsx
@@ -9,7 +9,6 @@ interface FileUploaderProps {
   buttonKind?: "default" | "secondary" | "tertiary" | "ghost" | "danger";
   buttonName?: string;
   fileSize?: number;
-  onError?: () => void;
   onChange?: (
     event: React.ChangeEvent<HTMLInputElement>,
     data: { result: string }
@@ -20,9 +19,7 @@ const FileUploader = ({
   buttonKind = "default",
   buttonName = "Add file",
   fileSize = 0.5,
-  onError = () => {
-    console.log("업로드가 가능한 파일 사이즈를 초과했습니다.");
-  },
+
   onChange = () => {},
 }: FileUploaderProps) => {
   const [attachment, setAttachment] = useState("");
@@ -34,34 +31,36 @@ const FileUploader = ({
   };
 
   const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const {
-      target: { files },
-    } = event;
+    try {
+      const {
+        target: { files },
+      } = event;
 
-    if (files === null) throw Error("적절한 파일이 입력되지 않았습니다.");
+      if (files === null) throw Error("적절한 파일이 입력되지 않았습니다.");
 
-    const theFile = files[0];
+      const theFile = files[0];
 
-    if (theFile.size > 1024 * 1024 * fileSize) {
-      onError();
-
-      throw Error(
-        `업로드할 수 있는 이미지 파일은 ${fileSize}MB 이하 사이즈만 가능합니다.`
-      );
-    }
-
-    setFilename(theFile.name);
-
-    const reader = new FileReader();
-
-    reader.onloadend = (finishedEvent: ProgressEvent<FileReader>) => {
-      const result = (finishedEvent.currentTarget as FileReader).result;
-      if (typeof result === "string") {
-        setAttachment(result);
-        onChange(event, { result: result });
+      if (theFile.size > 1024 * 1024 * fileSize) {
+        throw Error(
+          `업로드할 수 있는 이미지 파일은 ${fileSize}MB 이하 사이즈만 가능합니다.`
+        );
       }
-    };
-    reader.readAsDataURL(theFile);
+
+      setFilename(theFile.name);
+
+      const reader = new FileReader();
+
+      reader.onloadend = (finishedEvent: ProgressEvent<FileReader>) => {
+        const result = (finishedEvent.currentTarget as FileReader).result;
+        if (typeof result === "string") {
+          setAttachment(result);
+          onChange(event, { result: result });
+        }
+      };
+      reader.readAsDataURL(theFile);
+    } catch (err) {
+      alert(err);
+    }
   };
 
   const clearUploadedFile = () => {

--- a/src/components/FileUploaderDropContainer/FileUploaderDropContainer.stories.mdx
+++ b/src/components/FileUploaderDropContainer/FileUploaderDropContainer.stories.mdx
@@ -32,20 +32,6 @@ import FileUploaderDropContainer from "./FileUploaderDropContainer";
       },
       defaultValue: 0.5,
     },
-    onError: {
-      name: "onError",
-      type: { required: false },
-      description:
-        "FileUploaderDropContainer에 업로드할 수 있는 이미지 파일 사이즈 한도를 초과할 시, 실행할 함수를 설정할 수 있습니다.",
-      table: {
-        type: {
-          summary: "func",
-        },
-      },
-      defaultValue: () => {
-        console.log("업로드가 가능한 파일 사이즈를 초과했습니다.");
-      },
-    },
     onChange: {
       name: "onChange",
       type: { required: false },
@@ -57,7 +43,8 @@ import FileUploaderDropContainer from "./FileUploaderDropContainer";
         },
       },
     },
-  }}
+
+}}
 />
 
 # FileUploaderDropContainer


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정


### 반영 브랜치
chromatic -> main

### 변경 사항
1. Fix: FileUploader, FileUpladerDropContainer ui - throw error에 대한 에러핸들링
이미지 업로드를 했을 때의 각각 throw error에 대한 에러핸들링이 전무 했음.
try catch문으로 에러 핸들링 완료.